### PR TITLE
Enhancement/hud editor

### DIFF
--- a/src/main/java/net/oxyopia/vice/config/Config.java
+++ b/src/main/java/net/oxyopia/vice/config/Config.java
@@ -444,7 +444,7 @@ public class Config extends Vigilant {
     @Property(
         type = PropertyType.SWITCH,
         name = "Display Mobs Remaining",
-        description = "Adds a Mobs remaining stat to the Live Arena Info.",
+        description = "Adds a Mobs remaining stat to the Live Arena Information.",
         category = "Arenas",
         subcategory = "Live Arena Info"
     )
@@ -453,7 +453,7 @@ public class Config extends Vigilant {
     @Property(
         type = PropertyType.SWITCH,
         name = "Display Wave Timer",
-        description = "Displays the estimated time left for the current Wave.",
+		description = "Adds the time remaining for the wave to the Live Arena Information.",
         category = "Arenas",
         subcategory = "Live Arena Info"
     )
@@ -462,7 +462,7 @@ public class Config extends Vigilant {
     @Property(
         type = PropertyType.SELECTOR,
         name = "Display Projected Drops",
-        description = "Adds drops to Live Arena Info.\nBasic Drops: Amethyst, Polar Fur, Glowing Matter, etc\nUnique Drops: Chance for Galactic Hand Cannon, Arctic Scroll, etc",
+        description = "Adds drops to Live Arena Information.\nBasic Drops: Amethyst, Polar Fur, Glowing Matter, etc\nUnique Drops: Chance for Galactic Hand Cannon, Arctic Scroll, etc",
         category = "Arenas",
         subcategory = "Live Arena Info",
         options = {"None", "Basic Drops Only", "Unique Drops Only", "All"}

--- a/src/main/java/net/oxyopia/vice/config/DevConfig.java
+++ b/src/main/java/net/oxyopia/vice/config/DevConfig.java
@@ -3,6 +3,7 @@ package net.oxyopia.vice.config;
 import gg.essential.vigilance.Vigilant;
 import gg.essential.vigilance.data.*;
 
+import java.awt.*;
 import java.io.File;
 
 @SuppressWarnings("unused")

--- a/src/main/java/net/oxyopia/vice/config/DevConfig.java
+++ b/src/main/java/net/oxyopia/vice/config/DevConfig.java
@@ -3,7 +3,6 @@ package net.oxyopia.vice.config;
 import gg.essential.vigilance.Vigilant;
 import gg.essential.vigilance.data.*;
 
-import java.awt.*;
 import java.io.File;
 
 @SuppressWarnings("unused")

--- a/src/main/java/net/oxyopia/vice/config/HudEditor.kt
+++ b/src/main/java/net/oxyopia/vice/config/HudEditor.kt
@@ -12,19 +12,23 @@ import org.lwjgl.glfw.GLFW
 import kotlin.math.round
 
 object HudEditor : Screen(Text.of("Vice HUD Editor")) {
+	var renderAll = true
+
 	override fun render(context: DrawContext, mouseX: Int, mouseY: Int, delta: Float) {
 		super.render(context, mouseX, mouseY, delta)
 
 		val previewPos = Position(context.scaledWindowWidth.toFloat() / 2, 10f)
-		var previewText = listOf(
+		var previewText = mutableListOf(
 			"&&bVice HUD Editor",
-			"&&7Hover over elements for extra info.",
-			"&&7Double-click elements to edit settings."
+			"&&7Double-click elements to edit settings.",
+			"&&7Press &&aQ&&7 to edit only visible elements."
 		)
+
+		if (!renderAll) previewText[2] = "&&7Press &&aQ&&7 to edit all enabled elements."
 
 		val element = HudElement.draggedElement ?: HudElement.hoveredElement
 		element?.apply {
-			previewText = listOf(
+			previewText = mutableListOf(
 				"&&b${getDisplayName()}",
 				"&&7x: &&a${position.x.toInt()}&&7, y: &&a${position.y.toInt()}&&7, scale: &&a${round(position.scale * 10) / 10.0}"
 			)
@@ -34,14 +38,17 @@ object HudEditor : Screen(Text.of("Vice HUD Editor")) {
 	}
 
 	override fun keyPressed(keyCode: Int, scanCode: Int, modifiers: Int): Boolean {
-		if (keyCode == GLFW.GLFW_KEY_T || keyCode == GLFW.GLFW_KEY_SLASH) {
-			Utils.sendViceMessage("Still in HUD Editor!")
-			Utils.playSound("block.note_block.pling", volume = 3f)
-		}
+		when {
+			keyCode == GLFW.GLFW_KEY_T || keyCode == GLFW.GLFW_KEY_SLASH -> {
+				Utils.sendViceMessage("Still in HUD Editor!")
+				Utils.playSound("block.note_block.pling", volume = 3f)
+			}
 
-		if (HudElement.hoveredElement != null) {
-			HudElement.hoveredElement?.keyPressed(keyCode, scanCode, modifiers)
-		} else HudElement.selectedElement?.keyPressed(keyCode, scanCode, modifiers)
+			keyCode == GLFW.GLFW_KEY_Q -> renderAll = !renderAll
+
+			HudElement.hoveredElement != null -> HudElement.hoveredElement?.keyPressed(keyCode, scanCode, modifiers)
+			else -> HudElement.selectedElement?.keyPressed(keyCode, scanCode, modifiers)
+		}
 
 		return super.keyPressed(keyCode, scanCode, modifiers)
 	}

--- a/src/main/java/net/oxyopia/vice/config/HudEditor.kt
+++ b/src/main/java/net/oxyopia/vice/config/HudEditor.kt
@@ -1,6 +1,5 @@
 package net.oxyopia.vice.config
 
-import net.minecraft.client.MinecraftClient
 import net.minecraft.client.gui.DrawContext
 import net.minecraft.client.gui.screen.Screen
 import net.minecraft.text.Text
@@ -9,7 +8,6 @@ import net.oxyopia.vice.data.gui.HudElement
 import net.oxyopia.vice.data.gui.Position
 import net.oxyopia.vice.events.HudEditorRenderEvent
 import net.oxyopia.vice.utils.HudUtils.drawStrings
-import net.oxyopia.vice.utils.Utils
 import org.lwjgl.glfw.GLFW
 import java.awt.Color
 import kotlin.math.round
@@ -44,14 +42,7 @@ object HudEditor : Screen(Text.of("Vice HUD Editor")) {
 	}
 
 	override fun keyPressed(keyCode: Int, scanCode: Int, modifiers: Int): Boolean {
-		val client = MinecraftClient.getInstance()
-
 		when {
-			keyCode == client.options.chatKey.defaultKey.code || keyCode == client.options.commandKey.defaultKey.code -> {
-				Utils.sendViceMessage("Still in HUD Editor!")
-				Utils.playSound("block.note_block.pling", volume = 3f)
-			}
-
 			keyCode == GLFW.GLFW_KEY_Q -> {
 				misc.showAllHudEditorElements = !misc.showAllHudEditorElements
 				Vice.storage.markDirty()

--- a/src/main/java/net/oxyopia/vice/config/HudEditor.kt
+++ b/src/main/java/net/oxyopia/vice/config/HudEditor.kt
@@ -28,7 +28,9 @@ object HudEditor : Screen(Text.of("Vice HUD Editor")) {
 			"&&7Press &&aQ&&7 to edit only visible elements."
 		)
 
-		if (!misc.showAllHudEditorElements) previewText[2] = "&&7Press &&aQ&&7 to edit all enabled elements."
+		if (!misc.showAllHudEditorElements) {
+			previewText[2] = "&&7Press &&aQ&&7 to edit all enabled elements."
+		}
 
 		val element = HudElement.draggedElement ?: HudElement.hoveredElement
 		element?.apply {
@@ -36,6 +38,10 @@ object HudEditor : Screen(Text.of("Vice HUD Editor")) {
 				"&&b${getDisplayName()}",
 				"&&7x: &&a${position.x.toInt()}&&7, y: &&a${position.y.toInt()}&&7, scale: &&a${round(position.scale * 10) / 10.0}"
 			)
+
+			if (HudElement.resettingElement == this) {
+				previewText.add("&&cRight Click again to reset to &&7(&&a0&&7, &&a0&&7, scale &&a1.0&&7)")
+			}
 		}
 
 		previewPos.drawStrings(previewText, context, 1000)

--- a/src/main/java/net/oxyopia/vice/config/features/MiscStorage.kt
+++ b/src/main/java/net/oxyopia/vice/config/features/MiscStorage.kt
@@ -5,6 +5,9 @@ import net.oxyopia.vice.data.gui.Position
 
 class MiscStorage {
 
+	@Expose
+	var showAllHudEditorElements: Boolean = true
+
     @Expose
 	var lastDailyReward: Long = -1L
 

--- a/src/main/java/net/oxyopia/vice/data/gui/HudElement.kt
+++ b/src/main/java/net/oxyopia/vice/data/gui/HudElement.kt
@@ -32,7 +32,7 @@ abstract class
 	open fun drawCondition(): Boolean = true
 	abstract fun shouldDraw(): Boolean
 	private fun shouldDrawInternal(): Boolean {
-		return shouldDraw() && MinecraftClient.getInstance().currentScreen == HudEditor && (HudEditor.renderAll || drawCondition())
+		return shouldDraw() && MinecraftClient.getInstance().currentScreen == HudEditor && (Vice.storage.misc.showAllHudEditorElements || drawCondition())
 	}
 
 	fun save() = storePosition(position)

--- a/src/main/java/net/oxyopia/vice/data/gui/HudElement.kt
+++ b/src/main/java/net/oxyopia/vice/data/gui/HudElement.kt
@@ -168,6 +168,7 @@ abstract class
 	private fun setInvisible() {
 		if (!visible) return
 
+		hovered = false
 		if (isHovered) syncHoverState()
 		if (isSelected) selectedElement = null
 

--- a/src/main/java/net/oxyopia/vice/data/gui/HudElement.kt
+++ b/src/main/java/net/oxyopia/vice/data/gui/HudElement.kt
@@ -29,9 +29,10 @@ abstract class
 	abstract fun storePosition(position: Position)
 	abstract fun Position.drawPreview(context: DrawContext): Pair<Float, Float>?
 
+	open fun drawCondition(): Boolean = true
 	abstract fun shouldDraw(): Boolean
 	private fun shouldDrawInternal(): Boolean {
-		return shouldDraw() && MinecraftClient.getInstance().currentScreen == HudEditor
+		return shouldDraw() && MinecraftClient.getInstance().currentScreen == HudEditor && (HudEditor.renderAll || drawCondition())
 	}
 
 	fun save() = storePosition(position)

--- a/src/main/java/net/oxyopia/vice/features/arenas/LiveArenaInformation.kt
+++ b/src/main/java/net/oxyopia/vice/features/arenas/LiveArenaInformation.kt
@@ -16,9 +16,12 @@ import kotlin.time.Duration.Companion.seconds
 object LiveArenaInformation : HudElement("Live Arena Information", Vice.storage.arenas.liveArenaPos) {
 	private const val WAVE_TIME_SECONDS = 60
 
+	override fun shouldDraw(): Boolean = Vice.config.LIVE_ARENA_TOGGLE
+	override fun drawCondition(): Boolean = ArenaSession.active && ArenaSession.relatedWorld == Utils.getDTWorld()
+
 	@SubscribeEvent
 	fun onHudRender(event: HudRenderEvent) {
-		if (!shouldDraw() || !ArenaSession.active || ArenaSession.relatedWorld != Utils.getDTWorld()) return
+		if (!shouldDraw() || !drawCondition()) return
 
 		val session = ArenaSession
 		val world = session.relatedWorld
@@ -49,10 +52,6 @@ object LiveArenaInformation : HudElement("Live Arena Information", Vice.storage.
 		}
 
 		position.drawStrings(list, event.context)
-	}
-
-	override fun shouldDraw(): Boolean {
-		return Vice.config.LIVE_ARENA_TOGGLE
 	}
 
 	override fun storePosition(position: Position) {

--- a/src/main/java/net/oxyopia/vice/features/auxiliary/exonitas/PowerBoxTimer.kt
+++ b/src/main/java/net/oxyopia/vice/features/auxiliary/exonitas/PowerBoxTimer.kt
@@ -23,9 +23,12 @@ object PowerBoxTimer : HudElement("Power Box Timer", Vice.storage.auxiliary.city
 	private var lastPowerBoxActivation = -1L
 	private var lastKnownLevel = -1
 
+	override fun shouldDraw(): Boolean = Vice.config.EXONITAS_POWER_BOX_TIMER
+	override fun drawCondition(): Boolean = World.Exonitas.isInWorld()
+
 	@SubscribeEvent
 	fun onTitle(event: TitleEvent) {
-		if (!World.Exonitas.isInWorld()) return
+		if (!drawCondition()) return
 
 		if (event.title.contains("GAME OVER")) {
 			lastKnownLevel = -1
@@ -64,10 +67,6 @@ object PowerBoxTimer : HudElement("Power Box Timer", Vice.storage.auxiliary.city
 		}
 
 		position.drawString(text, event.context)
-	}
-
-	override fun shouldDraw(): Boolean {
-		return Vice.config.EXONITAS_POWER_BOX_TIMER
 	}
 
 	override fun storePosition(position: Position) {

--- a/src/main/java/net/oxyopia/vice/features/auxiliary/exonitas/PowerBoxTimer.kt
+++ b/src/main/java/net/oxyopia/vice/features/auxiliary/exonitas/PowerBoxTimer.kt
@@ -75,6 +75,6 @@ object PowerBoxTimer : HudElement("Power Box Timer", Vice.storage.auxiliary.city
 	}
 
 	override fun Position.drawPreview(context: DrawContext): Pair<Float, Float> {
-		return Pair(position.drawString("&&c1.75s", context) * position.scale, 7f)
+		return Pair(position.drawString("&&a1.5s", context) * position.scale, 7f)
 	}
 }

--- a/src/main/java/net/oxyopia/vice/features/cooking/CurrentOrderDisplay.kt
+++ b/src/main/java/net/oxyopia/vice/features/cooking/CurrentOrderDisplay.kt
@@ -12,10 +12,10 @@ import net.oxyopia.vice.events.core.SubscribeEvent
 import net.oxyopia.vice.utils.HudUtils.drawStrings
 
 object CurrentOrderDisplay : HudElement("Cooking Display", storage.cooking.currentOrderPos, searchTerm = "cooking") {
-	private val player = MinecraftClient.getInstance().player
+	private val mc = MinecraftClient.getInstance()
 
 	override fun shouldDraw(): Boolean = config.SHOW_NEXT_COOKING_ITEM || config.SHOW_COOKING_STOCK_INFO
-	override fun drawCondition(): Boolean = World.Burger.isInWorld() && player != null && player.y > 100.0
+	override fun drawCondition(): Boolean = World.Burger.isInWorld() && (mc.player?.y ?: 0.0) > 100.0
 
 	@SubscribeEvent
 	fun onHudRender(event: HudRenderEvent) {

--- a/src/main/java/net/oxyopia/vice/features/cooking/CurrentOrderDisplay.kt
+++ b/src/main/java/net/oxyopia/vice/features/cooking/CurrentOrderDisplay.kt
@@ -12,10 +12,14 @@ import net.oxyopia.vice.events.core.SubscribeEvent
 import net.oxyopia.vice.utils.HudUtils.drawStrings
 
 object CurrentOrderDisplay : HudElement("Cooking Display", storage.cooking.currentOrderPos, searchTerm = "cooking") {
+	private val player = MinecraftClient.getInstance().player
+
+	override fun shouldDraw(): Boolean = config.SHOW_NEXT_COOKING_ITEM || config.SHOW_COOKING_STOCK_INFO
+	override fun drawCondition(): Boolean = World.Burger.isInWorld() && player != null && player.y > 100.0
+
 	@SubscribeEvent
 	fun onHudRender(event: HudRenderEvent) {
-		val mc = MinecraftClient.getInstance()
-		if (mc.player == null || !World.Burger.isInWorld() || mc.player!!.y <= 100.0) return
+		if (!drawCondition()) return
 
 		val displayList: MutableList<String> = mutableListOf()
 
@@ -76,10 +80,6 @@ object CurrentOrderDisplay : HudElement("Cooking Display", storage.cooking.curre
 	override fun storePosition(position: Position) {
 		storage.cooking.currentOrderPos = position
 		storage.markDirty()
-	}
-
-	override fun shouldDraw(): Boolean {
-		return config.SHOW_NEXT_COOKING_ITEM || config.SHOW_COOKING_STOCK_INFO
 	}
 
 	override fun Position.drawPreview(context: DrawContext): Pair<Float, Float> {

--- a/src/main/java/net/oxyopia/vice/features/cooking/OrderTracker.kt
+++ b/src/main/java/net/oxyopia/vice/features/cooking/OrderTracker.kt
@@ -13,14 +13,14 @@ import net.oxyopia.vice.utils.HudUtils.drawStrings
 object OrderTracker : HudElement("Cooking Order Tracker", Vice.storage.cooking.orderTrackerPos, searchTerm = "order tracker") {
 	private val requests get() = Vice.storage.cooking.totalBurgerRequests
 	private val completions get() = Vice.storage.cooking.totalBurgersComplete
+	private val player = MinecraftClient.getInstance().player
+
+	override fun shouldDraw(): Boolean = Vice.config.COOKING_ORDER_TRACKER
+	override fun drawCondition(): Boolean = World.Burger.isInWorld() && player != null && player.y > 100.0
 
 	@SubscribeEvent
 	fun onHudRender(event: HudRenderEvent) {
-		val mc = MinecraftClient.getInstance()
-
-		if (!Vice.config.COOKING_ORDER_TRACKER) return
-		if (mc.player == null || !World.Burger.isInWorld() || mc.player!!.y <= 100.0) return
-
+		if (!Vice.config.COOKING_ORDER_TRACKER || !drawCondition()) return
 		draw(position, event.context)
 	}
 
@@ -74,8 +74,6 @@ object OrderTracker : HudElement("Cooking Order Tracker", Vice.storage.cooking.o
 		Vice.storage.cooking.orderTrackerPos = position
 		Vice.storage.markDirty()
 	}
-
-	override fun shouldDraw(): Boolean = Vice.config.COOKING_ORDER_TRACKER
 
 	override fun Position.drawPreview(context: DrawContext): Pair<Float, Float> {
 		return draw(this, context)

--- a/src/main/java/net/oxyopia/vice/features/cooking/OrderTracker.kt
+++ b/src/main/java/net/oxyopia/vice/features/cooking/OrderTracker.kt
@@ -13,10 +13,10 @@ import net.oxyopia.vice.utils.HudUtils.drawStrings
 object OrderTracker : HudElement("Cooking Order Tracker", Vice.storage.cooking.orderTrackerPos, searchTerm = "order tracker") {
 	private val requests get() = Vice.storage.cooking.totalBurgerRequests
 	private val completions get() = Vice.storage.cooking.totalBurgersComplete
-	private val player = MinecraftClient.getInstance().player
+	private val mc = MinecraftClient.getInstance()
 
 	override fun shouldDraw(): Boolean = Vice.config.COOKING_ORDER_TRACKER
-	override fun drawCondition(): Boolean = World.Burger.isInWorld() && player != null && player.y > 100.0
+	override fun drawCondition(): Boolean = World.Burger.isInWorld() && (mc.player?.y ?: 0.0) > 100.0
 
 	@SubscribeEvent
 	fun onHudRender(event: HudRenderEvent) {

--- a/src/main/java/net/oxyopia/vice/features/hud/TrainTimer.kt
+++ b/src/main/java/net/oxyopia/vice/features/hud/TrainTimer.kt
@@ -26,10 +26,12 @@ object TrainTimer : HudElement("Train Timer", Vice.storage.showdown.trainTimerPo
 	private val spawnTime get() = Vice.storage.showdown.lastKnownTrainSpawn
 	private var aliveCount = 0
 
+	override fun shouldDraw(): Boolean = Vice.config.TRAIN_TIMER
+	override fun drawCondition(): Boolean = Vice.config.TRAIN_TIMER_OUTSIDE || World.Showdown.isInWorld()
+
 	@SubscribeEvent
 	fun onHudRender(event: HudRenderEvent) {
-		if (!Vice.config.TRAIN_TIMER) return
-		if (!Vice.config.TRAIN_TIMER_OUTSIDE && !World.Showdown.isInWorld()) return
+		if (!Vice.config.TRAIN_TIMER || !drawCondition()) return
 
 		val list: MutableList<String> = mutableListOf()
 
@@ -86,8 +88,6 @@ object TrainTimer : HudElement("Train Timer", Vice.storage.showdown.trainTimerPo
 		Vice.storage.showdown.trainTimerPos = position
 		Vice.storage.markDirty()
 	}
-
-	override fun shouldDraw(): Boolean = Vice.config.TRAIN_TIMER
 
 	override fun Position.drawPreview(context: DrawContext): Pair<Float, Float> {
 		val list = listOf(

--- a/src/main/java/net/oxyopia/vice/mixin/MixinInGameHud.java
+++ b/src/main/java/net/oxyopia/vice/mixin/MixinInGameHud.java
@@ -44,16 +44,7 @@ public class MixinInGameHud {
 	@Inject(at = @At(value="INVOKE", target="Lnet/minecraft/client/network/ClientPlayerEntity;getSleepTimer()I", ordinal = 0), method = "render")
 	private void hudRenderEvent(DrawContext context, float tickDelta, CallbackInfo ci) {
 		if (Utils.INSTANCE.getInDoomTowers()) {
-			if (Utils.INSTANCE.getClient().currentScreen == HudEditor.INSTANCE) {
-				MinecraftClient client = MinecraftClient.getInstance();
-				Window window = client.getWindow();
-
-				int mouseX = MathHelper.floor(client.mouse.getX() * (double)window.getScaledWidth() / (double)window.getWidth());
-				int mouseY = MathHelper.floor(client.mouse.getY() * (double)window.getScaledHeight() / (double)window.getHeight());
-
-				EVENT_MANAGER.publish(new HudEditorRenderEvent(context, mouseX, mouseY, tickDelta));
-
-			} else {
+			if (Utils.INSTANCE.getClient().currentScreen != HudEditor.INSTANCE) {
 				EVENT_MANAGER.publish(new HudRenderEvent(context, this.scaledWidth, this.scaledHeight));
 			}
 		}

--- a/src/main/java/net/oxyopia/vice/mixin/MixinInGameHud.java
+++ b/src/main/java/net/oxyopia/vice/mixin/MixinInGameHud.java
@@ -1,14 +1,11 @@
 package net.oxyopia.vice.mixin;
 
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.InGameHud;
-import net.minecraft.client.util.Window;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.scoreboard.ScoreboardObjective;
 import net.minecraft.text.Text;
-import net.minecraft.util.math.MathHelper;
 import net.oxyopia.vice.config.HudEditor;
 import net.oxyopia.vice.events.*;
 import net.oxyopia.vice.utils.Utils;


### PR DESCRIPTION
Hud Editor Improvements

- Added filtering between enabled and only visible elements.
- Added a background gradient
- Added double-click functionality to edit settings of elements (2840e17)
- Added information to infobox while not hovering over elements (2840e17)
- Added information to infobox when initailly right-clicking elements
- Removed 'Still in HUD Editor' message when clicking chat keybinds
- Fixed incorrect preview color for Power Box Timer
- Fixed elements being editable after toggled in-UI
- Fixed elements not rendering after being hidden (416cd46)
- Adjusted wording relating to Live Arena Info in configs
- Moved HudEditorRenderEvent invocation into HudEditor rather than MixinInGameHud